### PR TITLE
fix android p bug

### DIFF
--- a/shapesimage/src/main/java/net/karthikraj/shapesimage/ShapesImage.java
+++ b/shapesimage/src/main/java/net/karthikraj/shapesimage/ShapesImage.java
@@ -587,8 +587,11 @@ public class ShapesImage extends ImageView {
             if (mMaskDrawable != null) {
                 int sc = cacheCanvas.save();
                 mMaskDrawable.draw(cacheCanvas);
-                cacheCanvas.saveLayer(mBoundsF, mMaskedPaint,
-                        Canvas.HAS_ALPHA_LAYER_SAVE_FLAG | Canvas.FULL_COLOR_LAYER_SAVE_FLAG);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    cacheCanvas.saveLayer(mBoundsF, mMaskedPaint);
+                }else{
+                    cacheCanvas.saveLayer(mBoundsF, mMaskedPaint,Canvas.ALL_SAVE_FLAG);
+                }
                 super.onDraw(cacheCanvas);
                 cacheCanvas.restoreToCount(sc);
             }else {


### PR DESCRIPTION
in android p (28) args of canvas.saveLayer changed and Canvas.HAS_ALPHA_LAYER_SAVE_FLAG , Canvas.FULL_COLOR_LAYER_SAVE_FLAG deprecated and not exist
https://developer.android.com/reference/android/graphics/Canvas 